### PR TITLE
Refactor distributor so that it can used as a torrent-serving library in other applications.

### DIFF
--- a/distributor/distributor.go
+++ b/distributor/distributor.go
@@ -44,8 +44,9 @@ func main() {
 	} else if *verbose {
 		verbosity = torrent.VerbVerbose
 	}
+	torrent.SetLoggingVerbosity(verbosity)
 
-	distributor, err := torrent.NewDistributor(verbosity, *dir, *ctorrent, *listen, *port)
+	distributor, err := torrent.NewDistributor(*dir, *ctorrent, *listen, *port)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error Creating distributor: %v\n", err)
 		os.Exit(1)

--- a/torrent/doc.go
+++ b/torrent/doc.go
@@ -1,0 +1,19 @@
+package torrent
+
+// This package provides a distributor library that can be used by other go
+// applications to provide torrent services.
+//
+// To use, just create a distributor, and starts its "Run" message in a goroutine:
+//
+//    distributor, err := torrent.NewDistributor(VerbNormal, "dirname", "/usr/local/bin/ctorrent",
+//           "127.0.0.1", 6390)
+//	   if err != nil {
+//	      fmt.Fprintf(os.Stderr, "Error Creating distributor: %v\n", err)
+//        os.Exit(1)
+//     }
+//     go distributor.Run()
+//
+// To stop the distributor cleanly, call its "Close" method:
+//
+//     distributor.Close()
+//

--- a/torrent/driver.go
+++ b/torrent/driver.go
@@ -7,27 +7,17 @@ import (
 	"path"
 )
 
-type Verbosity uint32
-
-const (
-	VerbNormal  = Verbosity(0)
-	VerbVerbose = Verbosity(1)
-	VerbDebug   = Verbosity(2)
-)
-
 type Distributor struct {
-	verbosity Verbosity
-	dir       string
-	ctorrent  string
-	address   string
-	port      int
-	quitChan  chan bool
-	watchers  map[string]*Watcher
-	tracker   *Tracker
+	dir      string
+	ctorrent string
+	address  string
+	port     int
+	quitChan chan bool
+	watchers map[string]*Watcher
+	tracker  *Tracker
 }
 
 func NewDistributor(
-	verbosity Verbosity,
 	dir string,
 	ctorrentPath string,
 	address string,
@@ -50,12 +40,11 @@ func NewDistributor(
 		return nil, errors.New("port must be in range 1..65535")
 	}
 	return &Distributor{
-		verbosity: verbosity,
-		dir:       dir,
-		ctorrent:  ctorrentPath,
-		address:   address,
-		port:      port,
-		quitChan:  make(chan bool),
+		dir:      dir,
+		ctorrent: ctorrentPath,
+		address:  address,
+		port:     port,
+		quitChan: make(chan bool),
 	}, nil
 
 }

--- a/torrent/driver.go
+++ b/torrent/driver.go
@@ -1,0 +1,80 @@
+package torrent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+)
+
+type Verbosity uint32
+
+const (
+	VerbNormal  = Verbosity(0)
+	VerbVerbose = Verbosity(1)
+	VerbDebug   = Verbosity(2)
+)
+
+type Distributor struct {
+	verbosity Verbosity
+	dir       string
+	ctorrent  string
+	address   string
+	port      int
+	quitChan  chan bool
+	watchers  map[string]*Watcher
+	tracker   *Tracker
+}
+
+func NewDistributor(
+	verbosity Verbosity,
+	dir string,
+	ctorrentPath string,
+	address string,
+	port int) (*Distributor, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		LogError("serve path does not exist: %s", err)
+		return nil, err
+	}
+	if !info.IsDir() {
+		LogError("serve path is not a directory")
+		return nil, errors.New("serve path is not a directory")
+	}
+	if _, err = os.Stat(ctorrentPath); err != nil {
+		LogError("ctorrent binary not found at: %s", ctorrentPath)
+		return nil, errors.New(fmt.Sprintf("ctorrent binary not found at: %s", ctorrentPath))
+	}
+	if port < 1 || port > 65535 {
+		LogError("port must be in range 1..65535")
+		return nil, errors.New("port must be in range 1..65535")
+	}
+	return &Distributor{
+		verbosity: verbosity,
+		dir:       dir,
+		ctorrent:  ctorrentPath,
+		address:   address,
+		port:      port,
+		quitChan:  make(chan bool),
+	}, nil
+
+}
+
+func (dist *Distributor) Run() {
+	// The basic flow is that we set up a tracker, which listens on a port for HTTP requests. The
+	// tracker coordinates peers and torrent files. To each tracker we can attach a set of watchers,
+	// which handle monitoring of files.
+	dist.watchers = map[string]*Watcher{
+		path.Base(dist.dir): StartWatcher(dist.dir),
+	}
+	dist.tracker = StartTracker(dist.address, dist.port, dist.ctorrent, dist.watchers)
+	LogInfo("distributing %s on %s:%d", dist.dir, dist.address, dist.port)
+	<-dist.quitChan
+}
+
+func (dist *Distributor) Close() {
+	for _, w := range dist.watchers {
+		w.Close()
+	}
+	dist.quitChan <- true
+}

--- a/torrent/logging.go
+++ b/torrent/logging.go
@@ -6,31 +6,37 @@
  *
  */
 
-package main
+package torrent
 
 import (
 	"log"
 )
 
-func loginfo(fmt string, args ...interface{}) {
+var VERBOSITY uint32 = 0
+
+func SetLoggingVerbosity(level uint32) {
+	VERBOSITY = level
+}
+
+func LogInfo(fmt string, args ...interface{}) {
 	if VERBOSITY >= 1 {
 		log.Printf("[INFO] "+fmt, args...)
 	}
 }
 
-func logwarning(fmt string, args ...interface{}) {
+func LogWarning(fmt string, args ...interface{}) {
 	log.Printf("[WARNING] "+fmt, args...)
 }
 
-func logerror(fmt string, args ...interface{}) {
+func LogError(fmt string, args ...interface{}) {
 	log.Printf("[ERROR] "+fmt, args...)
 }
 
-func logfatal(fmt string, args ...interface{}) {
+func LogFatal(fmt string, args ...interface{}) {
 	log.Fatalf("[FATAL] "+fmt, args...)
 }
 
-func logdebug(fmt string, args ...interface{}) {
+func LogDebug(fmt string, args ...interface{}) {
 	if VERBOSITY >= 2 {
 		log.Printf("[DEBUG] "+fmt, args...)
 	}

--- a/torrent/logging.go
+++ b/torrent/logging.go
@@ -12,14 +12,22 @@ import (
 	"log"
 )
 
-var VERBOSITY uint32 = 0
+type Verbosity uint32
 
-func SetLoggingVerbosity(level uint32) {
+const (
+	VerbNormal  = Verbosity(0)
+	VerbVerbose = Verbosity(1)
+	VerbDebug   = Verbosity(2)
+)
+
+var VERBOSITY Verbosity = VerbNormal
+
+func SetLoggingVerbosity(level Verbosity) {
 	VERBOSITY = level
 }
 
 func LogInfo(fmt string, args ...interface{}) {
-	if VERBOSITY >= 1 {
+	if VERBOSITY >= VerbVerbose {
 		log.Printf("[INFO] "+fmt, args...)
 	}
 }
@@ -37,7 +45,7 @@ func LogFatal(fmt string, args ...interface{}) {
 }
 
 func LogDebug(fmt string, args ...interface{}) {
-	if VERBOSITY >= 2 {
+	if VERBOSITY >= VerbDebug {
 		log.Printf("[DEBUG] "+fmt, args...)
 	}
 }

--- a/torrent/torrent_test.go
+++ b/torrent/torrent_test.go
@@ -1,4 +1,4 @@
-package main
+package torrent
 
 import (
 	"github.com/stretchr/testify/assert"
@@ -16,7 +16,7 @@ func TestMakeHashesEmptyFile(t *testing.T) {
 	reader := strings.NewReader(test_file)
 	hashes, bytesRead, err := makeHashes(reader, 0)
 	assert.Nil(t, err)
-	assert.Equal(t, bytesRead, 0, "should be 0")
+	assert.Equal(t, bytesRead, int64(0), "should be 0")
 	assert.Empty(t, hashes)
 }
 
@@ -25,7 +25,7 @@ func TestMakeHashesOneChunk(t *testing.T) {
 	reader := strings.NewReader(test_file)
 	hashes, bytesRead, err := makeHashes(reader, int64(len(test_file)))
 	assert.Nil(t, err)
-	assert.Equal(t, bytesRead, len(test_file), "should match the length of the file")
+	assert.Equal(t, bytesRead, int64(len(test_file)), "should match the length of the file")
 	assert.Len(t, hashes, 1, "should have one chunk")
 
 	bytes := []byte{220, 114, 74, 241, 143, 189, 212, 229, 145, 137, 245, 254, 118, 138, 95,
@@ -41,7 +41,7 @@ func TestMakeHashesTwoChunks(t *testing.T) {
 	reader := strings.NewReader(test_file)
 	hashes, bytesRead, err := makeHashes(reader, int64(len(test_file)))
 	assert.Nil(t, err)
-	assert.Equal(t, bytesRead, len(test_file), "should match the length of the file")
+	assert.Equal(t, bytesRead, int64(len(test_file)), "should match the length of the file")
 	assert.Len(t, hashes, 2, "should have one chunk")
 
 	bytes := []byte{247, 218, 76, 179, 188, 125, 55, 53, 207, 46, 38, 44, 239, 5, 213,


### PR DESCRIPTION
- Move distributor.go into new "main" sub-package;
- Move the rest of the code into a package "distributor/torrent".
- Modify API so that users can create trackers, and start and stop
   their goroutines.
- Add a doc.go file to the library package explaining how to use distributor
  as a library.
