### PR TITLE
Allow multiple peers from the same IP address, but different ports

### DIFF
--- a/torrent/driver.go
+++ b/torrent/driver.go
@@ -43,11 +43,12 @@ func NewDistributor(
 		return nil, errors.New("port must be in range 1..65535")
 	}
 	return &Distributor{
-		dir:      dir,
-		ctorrent: ctorrentPath,
-		address:  address,
-		port:     port,
-		quitChan: make(chan bool),
+		dir:       dir,
+		ctorrent:  ctorrentPath,
+		address:   address,
+		port:      port,
+		quitChan:  make(chan bool),
+		verbosity: verbosity,
 	}, nil
 
 }

--- a/torrent/tracker.go
+++ b/torrent/tracker.go
@@ -328,14 +328,14 @@ func (self *Tracker) handleAnnounce(w http.ResponseWriter, r *http.Request) {
 		peerage = time.Since(peerlastseen)
 	}
 
-	// Add this peer to the set if they don't exist, plus possibly purge other peers on this IP.
+	// Add this peer to the set if they don't exist, plus possibly purge other peers on this IP and port.
 	if _, ok := peers[peer.Id]; !ok {
-		// Remove any other peers on this IP address. This is kind of a hack since we don't have
+		// Remove any other peers on this IP address and port. This is kind of a hack since we don't have
 		// "last reported time" at the moment. If a new peer starts up on a host, then we remove
 		// the other one.
 		toRemove := make([]string, 0, 10)
 		for id, tmpPeer := range peers {
-			if tmpPeer.Ip == peer.Ip || (pok && peerage > 300*time.Second) {
+			if (tmpPeer.Ip == peer.Ip && tmpPeer.Port == peer.Port) || (pok && peerage > 300*time.Second) {
 				toRemove = append(toRemove, id)
 			}
 		}
@@ -366,7 +366,7 @@ func (self *Tracker) handleAnnounce(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 
-		if tmpPeer.Ip == peer.Ip {
+		if tmpPeer.Ip == peer.Ip && tmpPeer.Port == peer.Port {
 			// This helps avoid giving peers connections to their own machine, which seems
 			// to confuse ctorrent. It seems to mostly affect small clusters.
 			continue


### PR DESCRIPTION
1. Allow multiple peers from the same IP, but different ports. There are two changes to support this: first is to allow multiple peers from the same IP to register with the tracker simultaneously, second is to provide to new clients other peers on the same IP (but different port).

2. Verbosity flag was not passed to Distributor, so -verbose/-debug was not working.
