### PR TITLE
Remove old peers

### DIFF
--- a/torrent/tracker.go
+++ b/torrent/tracker.go
@@ -382,7 +382,7 @@ func (self *Tracker) handleAnnounce(w http.ResponseWriter, r *http.Request) {
 		peer.Ip, peer.Port, len(outPeers), len(peers))
 
 	// Build the output dictionary and return it.
-	err = bencode.Marshal(w, PeerResponse{Interval: rand.Intn(120) + 300, Peers: outPeers})
+	err = bencode.Marshal(w, PeerResponse{Interval: rand.Intn(120) + 120, Peers: outPeers})
 	if err != nil {
 		LogError("Failed to bencode: %s", err)
 	}


### PR DESCRIPTION
Old peers aren't being cleaned up correctly if they don't cleanly stop.